### PR TITLE
Fix DSA for function parameters.

### DIFF
--- a/lib/Sema/SemaOpenMP.cpp
+++ b/lib/Sema/SemaOpenMP.cpp
@@ -241,7 +241,7 @@ OpenMPClauseKind DSAStackTy::getDSA(StackTy::reverse_iterator Iter, VarDecl *D,
     //  File-scope or namespace-scope variables referenced in called routines
     //  in the region are shared unless they appear in a threadprivate
     //  directive.
-    if (!D->isFunctionOrMethodVarDecl())
+    if (!D->isFunctionOrMethodVarDecl() && D->getKind() != Decl::ParmVar)
       return OMPC_shared;
 
     // OpenMP [2.9.1.2, Data-sharing Attribute Rules for Variables Referenced


### PR DESCRIPTION
Function parameters are erroneously detected as shared.

This test comes from the gcc testsuite (omp-single-3), and clang-omp (a65de2d1) complains that `a` and `b` are not private while they actually are.
The error message is the following : `error: copyprivate variable must be threadprivate or private in the enclosing context`

```
extern void abort (void);

void
single (int a, int b)
{
  #pragma omp single copyprivate(a) copyprivate(b)
    {
      a = b = 5;
    }

  if (a != b)
    abort ();
}

int main()
{
  #pragma omp parallel
    single (1, 2);

  return 0;
}
```

This happens because `isFunctionOrMethodVarDecl` only check for `Decl::Var` and not for `Decl::ParmVar`.
According to the documentation it's the expected behaviour, so I guess the additional check belongs in `SemaOpenMP`.
